### PR TITLE
fix(hue): emit color on mouseup just like saturation does

### DIFF
--- a/src/components/hue/hue.vue
+++ b/src/components/hue/hue.vue
@@ -128,6 +128,7 @@ export default {
     handleMouseDown(e) {
       this.handleChange(e, true);
       window.addEventListener('mousemove', this.handleChange);
+      window.addEventListener('mouseup', this.handleChange);
       window.addEventListener('mouseup', this.handleMouseUp);
     },
     handleMouseUp(e) {
@@ -135,6 +136,7 @@ export default {
     },
     unbindEventListeners() {
       window.removeEventListener('mousemove', this.handleChange);
+      window.removeEventListener('mouseup', this.handleChange);
       window.removeEventListener('mouseup', this.handleMouseUp);
     },
   },


### PR DESCRIPTION
When you release your mouse when using the color `<saturation>` component, it will fire a 'change' event with the color. To be consistent, the `<hue>` component should also emit an event when the mouse is released. 

This becomes important when attempting to wrap this library with a consistent undo function. We don't want to record a history of all those events, just record the color when the user releases their mouse.