### PR TITLE
feat: add keyboard navigation support for swatches and twitter

### DIFF
--- a/src/components/swatches/swatches.vue
+++ b/src/components/swatches/swatches.vue
@@ -72,6 +72,8 @@ export default {
           :aria-selected="equal(c)"
           :data-color="c"
           :style="{ background: c }"
+          tabindex="0"
+          @keyup.enter="handlerClick(c)"
           @click="handlerClick(c)"
         >
           <div v-show="equal(c)" class="vc-swatches-pick">

--- a/src/components/twitter/twitter.vue
+++ b/src/components/twitter/twitter.vue
@@ -111,6 +111,9 @@ export default {
           background: color,
           boxShadow: `0 0 4px ${equal(color) ? color : 'transparent'}`,
         }"
+        role="button"
+        tabindex="0"
+        @keyup.enter="handlerClick(color)"
         @click="handlerClick(color)"
       />
       <div class="vc-twitter-hash">
@@ -188,7 +191,6 @@ border-radius: 4px;
 margin: 0 6px 6px 0;
 cursor: pointer;
 position: relative;
-outline: none;
 }
 .vc-twitter-clear {
 clear: both;


### PR DESCRIPTION
This PR adds keyboard navigation support for `<Swatches>` and `<Twitter>`.

`<Swatches>`: 
![Kapture 2022-11-30 at 14 12 41](https://user-images.githubusercontent.com/10095631/204721610-56ecd9f2-888b-4e44-98b1-1a60b2c83028.gif)

`<Twitter>`:
![Kapture 2022-11-30 at 14 14 04](https://user-images.githubusercontent.com/10095631/204721618-94d4919b-66d0-4ffe-a460-5d01bbdbb6a7.gif)
