### PR TITLE
Added license to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "module": "libs/index.js",
   "unpkg": "dist/index.min.js",
   "author": "chenkai",
+  "license": "MIT",
   "keywords": [
     "vue-color",
     "color",


### PR DESCRIPTION
When using this package in the project and scanning it using Synk, it is throwing warning given below:

Unknown license (new) [Medium Severity][https://snyk.io/vuln/snyk:lic:npm:ckpack:vue-color:Unknown] in @ckpack/vue-color@1.5.0
    introduced by @ckpack/vue-color@1.5.0

Synk is treating as if it doesn't have the license. Including the license in the package.json file will resolve this issue